### PR TITLE
Added unit tests based on the example provided in the README.md document based on four different input criteria: api alone; api and city; api, longitude, and latitude; api, zip code, and country. Also fixed a print function typo in the weathermap.py script

### DIFF
--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,0 +1,53 @@
+import unittest
+from weathermap import Weather
+
+API_key = "1614693317375115619fb2c3b21b09b9"
+
+class TestExample(unittest.TestCase):
+
+    def test_location_tracking(self):
+        # uses IP address coordinates
+        try:
+            weather_info = Weather(apikey=API_key)
+            weather_info.get_current_weather()
+            weather_info.get_forecast()
+        except ValueError:
+            self.fail("Unexpected ValueError raised")
+        except AssertionError:
+            self.fail("Unexpected AssertionError raised")
+
+    def test_city(self):
+        # uses coordinates for Tampa, Florida
+        try:
+            weather_info = Weather(apikey=API_key, city="Tampa")
+            weather_info.get_current_weather()
+            weather_info.get_forecast()
+        except ValueError:
+            self.fail("Unexpected ValueError raised")
+        except AssertionError:
+            self.fail("Unexpected AssertionError raised")
+
+    def test_lat_lon(self):
+        # uses coordinates for Tampa, Florida
+        try:
+            weather_info = Weather(apikey=API_key, lat=27.964157, lon=-82.452606)
+            weather_info.get_current_weather()
+            weather_info.get_forecast()
+        except ValueError:
+            self.fail("Unexpected ValueError raised")
+        except AssertionError:
+            self.fail("Unexpected AssertionError raised")
+
+    def test_zip_country(self):
+        # uses coordinates for Tampa, Florida -> Hillsborough County
+        try:
+            weather_info = Weather(apikey=API_key, zip_code="33592", country="US")
+            weather_info.get_current_weather()
+            weather_info.get_forecast()
+        except ValueError:
+            self.fail("Unexpected ValueError raised")
+        except AssertionError:
+            self.fail("Unexpected AssertionError raised")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,7 +1,7 @@
 import unittest
 from weathermap import Weather
 
-API_key = "1614693317375115619fb2c3b21b09b9"
+API_key = "insert"
 
 class TestExample(unittest.TestCase):
 

--- a/weathermap/weathermap.py
+++ b/weathermap/weathermap.py
@@ -205,7 +205,7 @@ class Weather(WeatherCache, LocationTrack):
                         and self.city is None):
                     raise ValueError("Please provide valid latitude and longitude values")
                 elif (self.zip_code or self.country) and (self.lat and self.lon and self.city) is None:
-                    raise ValueError("Please provide valid zip_code and county code values")
+                    raise ValueError("Please provide valid zip_code and country code values")
                 else:
                     raise ValueError("Must provide either city or latitude and longitude or zipcode and country "
                                      "code.")


### PR DESCRIPTION
> Seeking Help: Creating Test Cases for Error Checking #3

Decided to focus on the example provided which is writing some simple test cases for the Weather function. In order to get weather information, you are asked to input a minimum of either:
1) city
2) long, lat
3) zip code and country


In the example, you can just input the ```apikey``` to do based on location tracking which is shown in these lines
```python
# Initialize Weather without location to enable location tracking
weather_info_for_current_ip = Weather(apikey='YOUR_API_KEY')
```
 
For the zip_code and just api inputs, the tests failed. I just found a zip code from Tampa, Florida and used that. I don't know if there are specific criteria to choosing a zip code. I also don't know if the location tracking is working in the correct context.